### PR TITLE
RFC: Switch to a WinRPM binary

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ BinDeps
 MathProgBase 0.3.7 0.4.0-
 @osx Homebrew
 Compat
+@windows WinRPM

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -66,9 +66,6 @@ end
 # Windows
 @windows_only begin
     using WinRPM
-    # TODO: remove the next 2 lines once package is submitted to official repository
-    push!(WinRPM.sources, "http://download.opensuse.org/repositories/home:/kelman:/mingw-coinor/openSUSE_13.1")
-    WinRPM.update()
     provides(WinRPM.RPM, "Ipopt", [libipopt], os = :Windows)
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using BinDeps
 
 @BinDeps.setup
 
-windllname = "IpOpt-vc10"
+windllname = "libipopt-1"
 libipopt = library_dependency("libipopt", aliases=[windllname])
 
 ipoptname = "Ipopt-3.12.1"
@@ -64,28 +64,12 @@ end
 
 
 # Windows
-downloadsdir = BinDeps.downloadsdir(libipopt)
-libdir = BinDeps.libdir(libipopt)
-downloadname = "Ipopt-3.11.0-Win32-Win64-dll.7z"
-windir = WORD_SIZE == 32 ? "Win32" : "x64"
-
-# BinDeps complains about the .7z file on other platforms...
-@windows_only provides(BuildProcess,
-    (@build_steps begin
-        FileDownloader("http://www.coin-or.org/download/binary/Ipopt/$downloadname", joinpath(downloadsdir, downloadname))
-	CreateDirectory(BinDeps.srcdir(libipopt), true)
-	FileUnpacker(joinpath(downloadsdir, downloadname), BinDeps.srcdir(libipopt), joinpath(BinDeps.srcdir(libipopt),"lib","Win32"))
-	CreateDirectory(libdir, true)
-	@build_steps begin
-	    ChangeDirectory(joinpath(BinDeps.srcdir(libipopt),"lib",windir,"ReleaseMKL"))
-	    FileRule(joinpath(libdir,"$(windllname).dll"), @build_steps begin
-	        `cp *.dll $(libdir)`
-	    end)
-	end
-     end), libipopt, os = :Windows)
-
-@windows_only push!(BinDeps.defaults, BuildProcess)
+@windows_only begin
+    using WinRPM
+    # TODO: remove the next 2 lines once package is submitted to official repository
+    push!(WinRPM.sources, "http://download.opensuse.org/repositories/home:/kelman:/mingw-coinor/openSUSE_13.1")
+    WinRPM.update()
+    provides(WinRPM.RPM, "Ipopt", [libipopt], os = :Windows)
+end
 
 @BinDeps.install [:libipopt => :libipopt]
-
-@windows_only pop!(BinDeps.defaults)


### PR DESCRIPTION
add WinRPM to REQUIRE on Windows

Would fix #7 and #27. Should wait until it's submitted to the official repository instead of my personal project before merging. I'm waiting for the next ampl-mp release before submitting that (for the command-line executable), but reference blas and lapack, and mumps 4.10 are already there.