### PR TITLE
save the location of the ampl executable

### DIFF
--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -5,6 +5,7 @@ if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
 else
     error("Ipopt not properly installed. Please run Pkg.build(\"Ipopt\")")
 end
+amplexe = joinpath(dirname(libipopt), "..", "bin", "ipopt")
 
 using Compat
 


### PR DESCRIPTION
for the sake of AmplNLWriter.jl, cc @JackDunnNZ

Any alternate suggestions for what to name this variable? Could just use `Ipopt.ipopt` maybe?