### PR TITLE
add restoration phase options for MPB

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MathProgBase Interface
 
 Ipopt implements the solver-independent [MathProgBase](https://github.com/JuliaOpt/MathProgBase.jl) interface,
 and so can be used within modeling software like [JuMP](https://github.com/JuliaOpt/JuMP.jl).
-The solver object is called ``IpoptSolver``. All options listed in the [Ipopt documentation](http://www.coin-or.org/Ipopt/documentation/node39.html) may be passed directly. For example, you can suppress output by saying ``IpoptSolver(print_level=0)``.
+The solver object is called ``IpoptSolver``. All options listed in the [Ipopt documentation](http://www.coin-or.org/Ipopt/documentation/node39.html) may be passed directly. For example, you can suppress output by saying ``IpoptSolver(print_level=0)``. If you wish to pass an option specifically for the restoration phase, instead of using the prefix ``resto.``, use the prefix ``resto_``. For example ``IpoptSolver(resto_max_iter=0)``.
 
 C Interface Wrapper
 -------------------

--- a/src/IpoptSolverInterface.jl
+++ b/src/IpoptSolverInterface.jl
@@ -359,7 +359,11 @@ function optimize!(m::IpoptMathProgModel)
     end
     copy!(m.inner.x, m.warmstart) # set warmstart
     for (name,value) in m.options
-        addOption(m.inner, string(name), value)
+        sname = string(name)
+        if match(r"(^resto_)", sname) != nothing
+            sname = replace(sname, r"(^resto_)", "resto.")
+        end
+        addOption(m.inner, sname, value)
     end
     solveProblem(m.inner)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,3 +59,17 @@ rosenbrocktest(IpoptSolver())
 include(joinpath(Pkg.dir("MathProgBase"),"test","quadprog.jl"))
 quadprogtest(IpoptSolver())
 qpdualtest(IpoptSolver())
+
+# Test retoration only options
+#
+# Warm start with infeasible solution, force restoration on initial iteration. 
+# But limit to 0 iterations. Forces :UserLimit exit.
+m = MathProgSolverInterface.model(IpoptSolver(start_with_resto="yes", resto_max_iter=0))
+l = [1,1,1,1]
+u = [5,5,5,5]
+lb = [25, 40]
+ub = [Inf, 40]
+MathProgSolverInterface.loadnonlinearproblem!(m, 4, 2, l, u, lb, ub, :Min, HS071())
+MathProgSolverInterface.setwarmstart!(m,[0,15,15,11])
+MathProgSolverInterface.optimize!(m)
+@test MathProgSolverInterface.status(m) == :UserLimit


### PR DESCRIPTION
Allows the user to set ``resto.[option]`` options. 

Not sure if there is a better/preferred way of handling things like this?