### PR TITLE
Eliminate Homebrew ambiguity

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -67,7 +67,7 @@ provides(SimpleBuild,
 # OS X
 @osx_only begin
     using Homebrew
-    provides(Homebrew.HB, "ipopt", libipopt, os = :Darwin)
+    provides(Homebrew.HB, "staticfloat/juliadeps/ipopt", libipopt, os = :Darwin)
 end
 
 


### PR DESCRIPTION
This full path to the formula is required when somebody has also installed something from Homebrew/science, thereby confusing `brew` between `homebrew/science/ipopt` and `staticfloat/juliadeps/ipopt`.