### PR TITLE
build script fix for OS X

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -30,7 +30,7 @@ provides(SimpleBuild,
             @build_steps begin
                 ChangeDirectory(joinpath(srcdir,"ThirdParty","Blas"))
                 CreateDirectory("build", true)
-                `sed -i 's/wget"/wget --no-check-certificate"/g' get.Blas`
+                `sed -i.backup 's/wget"/wget --no-check-certificate"/g' get.Blas`
                 `./get.Blas`
             end
             @build_steps begin
@@ -41,7 +41,7 @@ provides(SimpleBuild,
             @build_steps begin
                 ChangeDirectory(joinpath(srcdir,"ThirdParty","Lapack"))
                 CreateDirectory("build", true)
-                `sed -i 's/wget"/wget --no-check-certificate"/g' get.Lapack`
+                `sed -i.backup 's/wget"/wget --no-check-certificate"/g' get.Lapack`
                 `./get.Lapack`
             end
             @build_steps begin


### PR DESCRIPTION
@tkelman @ccoffrin, this should fix the source build on OS X and doesn't require any travis changes for upstream packages.