### PR TITLE
store options as vector of tuples instead of Iterator of pairs

### DIFF
--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -5,7 +5,7 @@ const MPB = MathProgBase
 # Solver objects
 export IpoptSolver
 struct IpoptSolver <: MPB.AbstractMathProgSolver
-    options::Vector{Tuple}
+    options::Vector{Tuple} # list of options set in Ipopt on each MPB.optimize! call
 end
 function IpoptSolver(;kwargs...)
     args = Vector{Tuple}()

--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -7,7 +7,13 @@ export IpoptSolver
 struct IpoptSolver <: MPB.AbstractMathProgSolver
     options
 end
-IpoptSolver(;kwargs...) = IpoptSolver(kwargs)
+function IpoptSolver(;kwargs...)
+    args = Vector{Tuple}()
+    for arg in kwargs
+        push!(args, (arg.first, arg.second))
+    end
+    IpoptSolver(args)
+end
 
 mutable struct IpoptMathProgModel <: MPB.AbstractNonlinearModel
     inner::IpoptProblem

--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -10,7 +10,11 @@ end
 function IpoptSolver(;kwargs...)
     args = Vector{Tuple}()
     for arg in kwargs
-        push!(args, (arg.first, arg.second))
+        if isa(arg, Pair)
+            push!(args, (arg.first, arg.second))
+        else # is a tuple in v0.6
+            push!(args, arg)
+        end
     end
     IpoptSolver(args)
 end

--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -5,7 +5,7 @@ const MPB = MathProgBase
 # Solver objects
 export IpoptSolver
 struct IpoptSolver <: MPB.AbstractMathProgSolver
-    options
+    options::Vector{Tuple}
 end
 function IpoptSolver(;kwargs...)
     args = Vector{Tuple}()


### PR DESCRIPTION
This is done to be able to change the options inside other solvers by changing the vector of tuples as it was possible in julia v0.6.
It shouldn't change any behavior of Ipopt.

Reference: @mlubin 
https://discourse.julialang.org/t/updating-options-in-ipopt/16013/2