### PR TITLE
test callback

### DIFF
--- a/test/hs071_test.jl
+++ b/test/hs071_test.jl
@@ -96,14 +96,6 @@ function eval_h(x::Vector{Float64}, mode, rows::Vector{Int32}, cols::Vector{Int3
   end
 end
 
-function intermediate(alg_mod::Int, iter_count::Int,
-  obj_value::Float64, inf_pr::Float64, inf_du::Float64, mu::Float64,
-  d_norm::Float64, regularization_size::Float64, alpha_du::Float64, alpha_pr::Float64,
-  ls_trials::Int)
-  println("Iteration $iter_count, objective value is $obj_value.")
-  return true
-end
-
 n = 4
 x_L = [1.0, 1.0, 1.0, 1.0]
 x_U = [5.0, 5.0, 5.0, 5.0]
@@ -124,3 +116,17 @@ solvestat = solveProblem(prob)
 @test prob.x[3] ≈ 3.8211499817883077 atol=1e-5
 @test prob.x[4] ≈ 1.3794082897556983 atol=1e-5
 @test prob.obj_val ≈ 17.014017145179164 atol=1e-5
+
+# test callbacks 
+function intermediate(alg_mod::Int, iter_count::Int,
+  obj_value::Float64, inf_pr::Float64, inf_du::Float64, mu::Float64,
+  d_norm::Float64, regularization_size::Float64, alpha_du::Float64, alpha_pr::Float64,
+  ls_trials::Int)
+  return iter_count < 1  # interrupt after one iteration
+end
+
+setIntermediateCallback(prob, intermediate)
+
+solvestat = solveProblem(prob)
+
+@test Ipopt.ApplicationReturnStatus[solvestat] == :User_Requested_Stop

--- a/test/hs071_test.jl
+++ b/test/hs071_test.jl
@@ -117,12 +117,12 @@ solvestat = solveProblem(prob)
 @test prob.x[4] ≈ 1.3794082897556983 atol=1e-5
 @test prob.obj_val ≈ 17.014017145179164 atol=1e-5
 
-# test callbacks 
+# This tests callbacks.
 function intermediate(alg_mod::Int, iter_count::Int,
   obj_value::Float64, inf_pr::Float64, inf_du::Float64, mu::Float64,
   d_norm::Float64, regularization_size::Float64, alpha_du::Float64, alpha_pr::Float64,
   ls_trials::Int)
-  return iter_count < 1  # interrupt after one iteration
+  return iter_count < 1  # Interrupts after one iteration.
 end
 
 setIntermediateCallback(prob, intermediate)


### PR DESCRIPTION
The callback functionality is not currently being tested. A callback was defined but not registered with the problem. On macOS, the test fails with the message:
```
C API: Error During Test at /Users/dpo/dev/julia/Ipopt.jl/test/runtests.jl:5
  Got exception outside of a @test
  LoadError: ccall: could not find function SetIntermediateCallback in library /Users/dpo/dev/julia/Ipopt.jl/deps/usr/lib/libipopt.1.10.10.dylib
```
The issue is that
```
dpo:~/dev/julia/Ipopt.jl (test-callback %)$ nm /Users/dpo/dev/julia/Ipopt.jl/deps/usr/lib/libipopt.1.10.10.dylib | grep -i SetIntermediateCallback
00000000000151b0 t _SetIntermediateCallback
```
The problem presumably comes from IpoptBuilder.jl.