### PR TITLE
fix sign of hessian in maximization case

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -671,7 +671,7 @@ function MOI.optimize!(model::Optimizer)
                 end
             else
                 obj_factor *= objective_scale
-                eval_hessian_lagrangian(model, values, x, objective_scale*obj_factor, lambda)
+                eval_hessian_lagrangian(model, values, x, obj_factor, lambda)
             end
         end
     else


### PR DESCRIPTION
I tried to create a test to catch this, but Ipopt is so robust that it still solved the problem when the hessian has the wrong sign. (The number of iterations degrades, however.)