### PR TITLE
Use JLL artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
     - 1.0
     - 1.1
+    - 1
 notifications:
     email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ addons:
         - gfortran
 after_success:
     - echo $TRAVIS_JULIA_VERSION
-    - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("Ipopt")); using Coverage; Coveralls.submit(process_folder())'
+    - julia -e 'using Pkg; Pkg.add("Coverage"); cd(Pkg.dir("Ipopt")); using Coverage; Coveralls.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.6.1"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
@@ -12,6 +13,7 @@ MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
 
 [compat]
 BinaryProvider = "0.5.3"
+Ipopt_jll = "3.13.1"
 MathOptInterface = "~0.9.5"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1
 
 platform:
   - x86 # 32-bit

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -9,7 +9,7 @@ if VERSION < v"1.3"
         error("Ipopt not properly installed. Please run import Pkg; Pkg.build(\"Ipopt\")")
     end
     const libipopt_path = Libdl.dlpath(libipopt)
-    const amplexe_path = Libdl.dlpath(amplexe)
+    const amplexe_path = amplexe
 
     function amplexefun(arguments::String)
         temp_env = copy(ENV)


### PR DESCRIPTION
I recently built Ipopt binaries in the form of JLLs for all platforms supported by BinaryBuilder. This PR pulls Ipopt_jll instead of using BinaryProvider explicitly. As a bonus, Ipopt.jl should now also run on FreeBSD and PowerPC.

The part commented out in `amplexefun()` screws up the environment so that libraries can't be found. I'm not sure what the purpose of that part of the code was. Is it still necessary?
