### PR TITLE
MOI.Silent suppresses output, project starting point into defined bounds

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -893,11 +893,11 @@ function MOI.optimize!(model::Optimizer)
             if !(v.has_lower_bound && v.has_upper_bound)
                 continue
             elseif v.has_lower_bound && v.has_upper_bound
-                model.inner.x[i] = 0.5*(v.lower_bound + x.upper_bound)
+                model.inner.x[i] = 0.5*(v.lower_bound + v.upper_bound)
             elseif v.has_lower_bound
-                model.inner.x[i] = max(0.0, x.lower_bound)
+                model.inner.x[i] = max(0.0, v.lower_bound)
             elseif v.has_upper_bound
-                model.inner.x[i] = min(0.0, x.upper_bound)
+                model.inner.x[i] = min(0.0, v.upper_bound)
             end
         end
     end
@@ -922,7 +922,7 @@ function MOI.optimize!(model::Optimizer)
     model.inner.mult_x_U = [v.upper_bound_dual_start === nothing ? 0.0 : v.lower_bound_dual_start
                             for v in model.variable_info]
 
-    model.silent && addOption(model.inner, "print_level ", 0)
+    model.silent && addOption(model.inner, "print_level", 0)
 
     for (name, value) in model.options
         addOption(model.inner, name, value)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -885,17 +885,19 @@ function MOI.optimize!(model::Optimizer)
     end
 
     # If nothing is provided, the default starting value is 0.0.
-    if v.start !== nothing
-        model.inner.x = v.start
-    else
-        model.inner.x = fill(0.0, num_variables)
-        for (i, v) in enumerate(model.variable_info)
-            if v.has_lower_bound && v.has_upper_bound
+    model.inner.x = fill(0.0, num_variables)
+    for (i, v) in enumerate(model.variable_info)
+        if v.start !== nothing
+            model.inner.x[i] = v.start
+        else
+            if !(v.has_lower_bound && v.has_upper_bound)
+                continue
+            elseif v.has_lower_bound && v.has_upper_bound
                 model.inner.x[i] = 0.5*(v.lower_bound + x.upper_bound)
             elseif v.has_lower_bound
-                model.inner.x[i] = x.lower_bound
+                model.inner.x[i] = max(0.0, x.lower_bound)
             elseif v.has_upper_bound
-                model.inner.x[i] = x.upper_bound]
+                model.inner.x[i] = min(0.0, x.upper_bound)
             end
         end
     end


### PR DESCRIPTION
Should address #183 and #185. 

- Causes MOI.Silent to suppress output by setting print_level to zero 0. This is overridden by a if print_level parameter is specifically set.
- Default starting point: For two-sided variable constraints, the starting point is set to the midpoint. For one-sided variable constraints, the starting point is set to the bound if 0.0 is infeasible.  For unconstrained variables, a starting value of 0.0 is used.
- Fix a typo in interpreting status. 